### PR TITLE
Upgrade Delaunator to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,9 @@
   "module": "src/index.js",
   "devDependencies": {
     "@observablehq/tape": "~0.0.1",
+    "delaunator": "^2.0.0",
     "esm": "^3.0.7",
-    "delaunator": "^1.0.5",
     "rollup": "^0.57.1",
-    "rollup-plugin-commonjs": "^9.1.0",
     "rollup-plugin-node-resolve": "^3.3.0",
     "rollup-plugin-uglify": "^3.0.0",
     "tape": "4"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,3 @@
-import commonjs from "rollup-plugin-commonjs";
 import noderesolve from "rollup-plugin-node-resolve";
 import uglify from "rollup-plugin-uglify";
 
@@ -10,7 +9,6 @@ const banner = `// ${definition.homepage} Version ${definition.version}. Copyrig
 const config = (file, ...plugins) => ({
   input: "src/index.js",
   plugins: [
-    commonjs(),
     noderesolve(),
     ...plugins
   ],

--- a/src/delaunay.js
+++ b/src/delaunay.js
@@ -122,6 +122,6 @@ export default class Delaunay {
 }
 
 Delaunay.from = function(points, fx, fy) {
-  const {coords, halfedges, hull, triangles} = new Delaunator(points, fx, fy);
+  const {coords, halfedges, hull, triangles} = Delaunator.from(points, fx, fy);
   return new Delaunay(coords, halfedges, hull, triangles);
 };

--- a/test/delaunay-test.js
+++ b/test/delaunay-test.js
@@ -3,7 +3,7 @@ import Delaunay from "../src/delaunay.js";
 
 tape("Delaunay.from([[x0, y0], [x1, y1], …])", test => {
   let delaunay = Delaunay.from([[0, 0], [1, 0], [0, 1], [1, 1]]);
-  test.deepEqual(delaunay.points, [0, 0, 1, 0, 0, 1, 1, 1]);
+  test.deepEqual(delaunay.points, Float64Array.of(0, 0, 1, 0, 0, 1, 1, 1));
   test.deepEqual(delaunay.triangles, Uint32Array.of(0, 2, 1, 2, 3, 1));
   test.deepEqual(delaunay.halfedges, Int32Array.of(-1, 5, -1, -1, -1, 1));
 });


### PR DESCRIPTION
I converted Delaunator to a proper ES module now, so we can remove `rollup-plugin-commonjs`.