### PR TITLE
Stable order for segment clipping?

### DIFF
--- a/src/voronoi.js
+++ b/src/voronoi.js
@@ -179,7 +179,7 @@ export default class Voronoi {
   }
   _clipFinite(points) {
     const n = points.length;
-    let P = null, S;
+    let P = null;
     let x0, y0, x1 = points[n - 2], y1 = points[n - 1];
     let c0, c1 = this._regioncode(x1, y1);
     let e0, e1;
@@ -190,8 +190,21 @@ export default class Voronoi {
         e0 = e1, e1 = 0;
         if (P) P.push(x1, y1);
         else P = [x1, y1];
-      } else if (S = this._clipSegment(x0, y0, x1, y1, c0, c1)) {
-        const [sx0, sy0, sx1, sy1] = S;
+      } else {
+        let S, sx0, sy0, sx1, sy1;
+        if (c0 === 0) {
+          if (S = this._clipSegment(x0, y0, x1, y1, c0, c1)) {
+            [sx0, sy0, sx1, sy1] = S;
+          } else {
+            continue;
+          }
+        } else {
+          if (S = this._clipSegment(x1, y1, x0, y0, c1, c0)) {
+            [sx1, sy1, sx0, sy0] = S;
+          } else {
+            continue;
+          }
+        }
         if (c0) {
           e0 = e1, e1 = this._edgecode(sx0, sy0);
           if (e0 && e1) this._edge(points, e0, e1, P);

--- a/src/voronoi.js
+++ b/src/voronoi.js
@@ -118,20 +118,21 @@ export default class Voronoi {
     }
   }
   contains(i, x, y) {
-    const {delaunay: {points}} = this;
-    if (points.length === 0 || (x = +x, x !== x) || (y = +y, y !== y)) return false;
+    if ((x = +x, x !== x) || (y = +y, y !== y)) return false;
     return this._step(i, x, y) === i;
   }
   find(x, y, i = 0) {
-    const {delaunay: {points}} = this;
-    if (points.length === 0 || (x = +x, x !== x) || (y = +y, y !== y)) return -1;
-    for (let c; (c = this._step(i, x, y)) !== i; i = c);
-    return i;
+    if ((x = +x, x !== x) || (y = +y, y !== y)) return -1;
+    let c;
+    while ((c = this._step(i, x, y)) >= 0 && c !== i) i = c;
+    return c;
   }
   _step(i, x, y) {
     const {delaunay: {points, triangles}, edges, index} = this;
+    if (points.length === 0) return -1; // Empty triangulation.
     const j0 = index[i * 2];
     const j1 = index[i * 2 + 1];
+    if (j0 === j1) return -1; // Coincident point.
     let c = i, k = edges[j0] * 3;
     let dc = (x - points[c * 2]) ** 2 + (y - points[c * 2 + 1]) ** 2;
     switch (i) { // Test previous point on triangle (for hull).
@@ -239,7 +240,7 @@ export default class Voronoi {
   _clipInfinite(i, points, vx0, vy0, vxn, vyn) {
     let P = Array.from(points), p;
     if (p = this._project(P[0], P[1], vx0, vy0)) P.unshift(p[0], p[1]);
-    if (p = this._project(P[P.length - 2], P[P.length - 1], vxn, vyn)) P.push(p[0], p[1]);
+    if (p = this._project(P[P.length - 2], P[P.length - 1], vxn, vyn)) P.unshift(p[0], p[1]);
     if (P = this._clipFinite(i, P)) {
       for (let j = 0, n = P.length, c0, c1 = this._edgecode(P[n - 2], P[n - 1]); j < n; j += 2) {
         c0 = c1, c1 = this._edgecode(P[j], P[j + 1]);

--- a/src/voronoi.js
+++ b/src/voronoi.js
@@ -242,7 +242,7 @@ export default class Voronoi {
   _clipInfinite(points, vx0, vy0, vxn, vyn) {
     let P = Array.from(points), p;
     if (p = this._project(P[0], P[1], vx0, vy0)) P.unshift(p[0], p[1]);
-    if (p = this._project(P[P.length - 2], P[P.length - 1], vxn, vyn)) P.unshift(p[0], p[1]);
+    if (p = this._project(P[P.length - 2], P[P.length - 1], vxn, vyn)) P.push(p[0], p[1]);
     if (P = this._clipFinite(P)) {
       for (let i = 0, n = P.length, c0, c1 = this._edgecode(P[n - 2], P[n - 1]); i < n; i += 2) {
         c0 = c1, c1 = this._edgecode(P[i], P[i + 1]);
@@ -260,7 +260,9 @@ export default class Voronoi {
               case 0b0001: c0 = 0b0101, cx = this.xmin, cy = this.ymin; break; // left
             }
             if (containsOpen(P, cx, cy)) {
-              P.splice(i, 0, cx, cy), n += 2, i += 2;
+              if (i === 0) P.push(cx, cy);
+              else P.splice(i, 0, cx, cy), i += 2;
+              n += 2;
             }
           }
         }

--- a/src/voronoi.js
+++ b/src/voronoi.js
@@ -123,7 +123,7 @@ export default class Voronoi {
     const v = i * 4;
     return points === null ? false
         : V[v] || V[v + 1] ? containsInfinite(points, V[v], V[v + 1], V[v + 2], V[v + 3], x, y)
-        : containsFinite(points, x, y);
+        : containsClosed(points, x, y);
   }
   find(x, y, i = 0) {
     const {delaunay: {halfedges, points, triangles}, edges, index} = this;
@@ -220,7 +220,7 @@ export default class Voronoi {
     if (P) {
       e0 = e1, e1 = this._edgecode(P[0], P[1]);
       if (e0 && e1) this._edge(points, e0, e1, P);
-    } else if (containsFinite(points, (this.xmin + this.xmax) / 2, (this.ymin + this.ymax) / 2)) {
+    } else if (containsClosed(points, (this.xmin + this.xmax) / 2, (this.ymin + this.ymax) / 2)) {
       return [this.xmax, this.ymin, this.xmax, this.ymax, this.xmin, this.ymax, this.xmin, this.ymin];
     }
     return P;
@@ -259,7 +259,7 @@ export default class Voronoi {
               case 0b1001: c0 = 0b0001; continue; // bottom-left
               case 0b0001: c0 = 0b0101, cx = this.xmin, cy = this.ymin; break; // left
             }
-            if (containsInfinite(points, vx0, vy0, vxn, vyn, cx, cy)) {
+            if (containsOpen(P, cx, cy)) {
               P.splice(i, 0, cx, cy), n += 2, i += 2;
             }
           }
@@ -284,7 +284,7 @@ export default class Voronoi {
         case 0b1001: e0 = 0b0001; continue; // bottom-left
         case 0b0001: e0 = 0b0101, cx = this.xmin, cy = this.ymin; break; // left
       }
-      if (containsFinite(points, cx, cy)) {
+      if (containsClosed(points, cx, cy)) {
         P.push(cx, cy);
       }
     }
@@ -321,14 +321,22 @@ export default class Voronoi {
   }
 }
 
-function containsFinite(points, x, y) {
+function containsClosed(points, x, y) {
   const n = points.length;
   let x0, y0, x1 = points[n - 2], y1 = points[n - 1];
   for (let i = 0; i < n; i += 2) {
     x0 = x1, y0 = y1, x1 = points[i], y1 = points[i + 1];
-    if ((x1 - x0) * (y - y0) < (y1 - y0) * (x - x0)) {
-      return false;
-    }
+    if ((x1 - x0) * (y - y0) < (y1 - y0) * (x - x0)) return false;
+  }
+  return true;
+}
+
+function containsOpen(points, x, y) {
+  const n = points.length;
+  let x0, y0, x1 = points[0], y1 = points[1];
+  for (let i = 2; i < n; i += 2) {
+    x0 = x1, y0 = y1, x1 = points[i], y1 = points[i + 1];
+    if ((x1 - x0) * (y - y0) < (y1 - y0) * (x - x0)) return false;
   }
   return true;
 }

--- a/src/voronoi.js
+++ b/src/voronoi.js
@@ -240,7 +240,7 @@ export default class Voronoi {
   _clipInfinite(i, points, vx0, vy0, vxn, vyn) {
     let P = Array.from(points), p;
     if (p = this._project(P[0], P[1], vx0, vy0)) P.unshift(p[0], p[1]);
-    if (p = this._project(P[P.length - 2], P[P.length - 1], vxn, vyn)) P.unshift(p[0], p[1]);
+    if (p = this._project(P[P.length - 2], P[P.length - 1], vxn, vyn)) P.push(p[0], p[1]);
     if (P = this._clipFinite(i, P)) {
       for (let j = 0, n = P.length, c0, c1 = this._edgecode(P[n - 2], P[n - 1]); j < n; j += 2) {
         c0 = c1, c1 = this._edgecode(P[j], P[j + 1]);

--- a/test/voronoi-test.js
+++ b/test/voronoi-test.js
@@ -22,9 +22,9 @@ tape("voronoi.renderCell(i, context) is a noop for coincident points", test => {
 tape("voronoi.renderCell(i, context) handles midpoint coincident with circumcenter", test => {
   let voronoi = Delaunay.from([[0, 0], [1, 0], [0, 1]]).voronoi([-1, -1, 2, 2]);
   let context = new Context;
-  test.equal((voronoi.renderCell(0, context), context.toString()), `M-1,0.5L-1,-1L0.5,-1L0.5,0.5Z`);
-  test.equal((voronoi.renderCell(1, context), context.toString()), `M0.5,-1L2,-1L2,2L2,2L0.5,0.5Z`);
-  test.equal((voronoi.renderCell(2, context), context.toString()), `M2,2L-1,2L-1,0.5L0.5,0.5Z`);
+  test.equal((voronoi.renderCell(0, context), context.toString()), `M-1,-1L0.5,-1L0.5,0.5L-1,0.5Z`);
+  test.equal((voronoi.renderCell(1, context), context.toString()), `M2,-1L2,2L2,2L0.5,0.5L0.5,-1Z`);
+  test.equal((voronoi.renderCell(2, context), context.toString()), `M-1,2L-1,0.5L0.5,0.5L2,2Z`);
 });
 
 tape("voronoi.contains(i, x, y) is false for coincident points", test => {


### PR DESCRIPTION
Attempting to fix #37. When clipping the Voronoi cell segments, this orders the segment so that the starting point is inside the clip region, if possible. However, it looks like there’s still a problem with the bottom-left cell for reasons that are unclear to me. 😦 

Any chance you could take a look, @mourner?

![image](https://user-images.githubusercontent.com/230541/38585050-4f034b1e-3ccd-11e8-97b8-eab7dbd56e2b.png)

https://beta.observablehq.com/@mbostock/d3-delaunay-bug