### PR TITLE
Implement lazy walk.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,18 +63,7 @@ See also [*delaunay*.render](#delaunay_render).
 
 <a href="#delaunay_hull" name="delaunay_hull">#</a> <i>delaunay</i>.<b>hull</b>
 
-The convex hull as an Uint32Array [*i0*, *i1*, …] of triangle vertex indexes. For example, to render the exterior edges of the Delaunay triangulation:
-
-```js
-const {hull, triangles} = delaunay;
-const n = hull.length;
-let i0, i1 = triangles[hull[n - 1]] * 2;
-for (let i = 0; i < n; ++i) {
-  i0 = i1, i1 = triangles[hull[i]] * 2;
-  context.moveTo(points[i0], points[i0 + 1]);
-  context.lineTo(points[i1], points[i1 + 1]);
-}
-```
+TODO …
 
 See also [*delaunay*.renderHull](#delaunay_renderHull).
 
@@ -94,6 +83,18 @@ context.closePath();
 ```
 
 See also [*delaunay*.renderTriangle](#delaunay_renderTriangle).
+
+<a href="#delaunay_inedges" name="delaunay_inedges">#</a> <i>delaunay</i>.<b>inedges</b>
+
+TODO …
+
+<a href="#delaunay_outedges" name="delaunay_outedges">#</a> <i>delaunay</i>.<b>outedges</b>
+
+TODO …
+
+<a href="#delaunay_find" name="delaunay_find">#</a> <i>delaunay</i>.<b>find</b>(<i>x</i>, <i>y</i>[, <i>i</i>]) [<>](https://github.com/d3/d3-delaunay/blob/master/src/delaunay.js "Source")
+
+Returns the index of the input point that is closest to the specified point ⟨*x*, *y*⟩. The search is started at the specified point *i*. If *i* is not specified, it defaults to zero.
 
 <a href="#delaunay_render" name="delaunay_render">#</a> <i>delaunay</i>.<b>render</b>([<i>context</i>]) [<>](https://github.com/d3/d3-delaunay/blob/master/src/delaunay.js "Source")
 
@@ -127,14 +128,6 @@ Returns the [Voronoi diagram](#voronoi) for the associated [points](#delaunay_po
 
 The Voronoi diagram’s associated [Delaunay triangulation](#delaunay).
 
-<a href="#voronoi_halfedgeIndex" name="voronoi_halfedgeIndex">#</a> <i>voronoi</i>.<b>halfedgeIndex</b>
-
-…
-
-<a href="#voronoi_hullIndex" name="voronoi_hullIndex">#</a> <i>voronoi</i>.<b>hullIndex</b>
-
-…
-
 <a href="#voronoi_circumcenters" name="voronoi_circumcenters">#</a> <i>voronoi</i>.<b>circumcenters</b>
 
 The [circumcenters](http://mathworld.wolfram.com/Circumcenter.html) of the Delaunay triangles as a Float64Array [*cx0*, *cy0*, *cx1*, *cy1*, …]. Each contiguous pair of coordinates *cx*, *cy* is the circumcenter for the corresponding triangle. These circumcenters form the coordinates of the Voronoi cell polygons.
@@ -149,10 +142,6 @@ An Uint64Array [*vx0*, *vy0*, *wx0*, *wy0*, …] where each non-zero quadruple d
 <a href="#voronoi_ymax" name="voronoi_ymax">#</a> <i>voronoi</i>.<b>ymax</b><br>
 
 The bounds of the viewport [*xmin*, *ymin*, *xmax*, *ymax*] for rendering the Voronoi diagram. These values only affect the rendering methods ([*voronoi*.render](#voronoi_render), [*voronoi*.renderBounds](#voronoi_renderBounds), [*cell*.render](#cell_render)).
-
-<a href="#voronoi_find" name="voronoi_find">#</a> <i>voronoi</i>.<b>find</b>(<i>x</i>, <i>y</i>[, <i>i</i>]) [<>](https://github.com/d3/d3-delaunay/blob/master/src/voronoi.js "Source")
-
-Returns the index of the cell that contains the specified point ⟨*x*, *y*⟩. The search is started at the specified point *i*. If *i* is not specified, it defaults to zero. (This method is not affected by the associated Voronoi diagram’s viewport [bounds](#voronoi_xmin).)
 
 <a href="#voronoi_contains" name="voronoi_contains">#</a> <i>voronoi</i>.<b>contains</b>(<i>i</i>, <i>x</i>, <i>y</i>) [<>](https://github.com/d3/d3-delaunay/blob/master/src/cell.js "Source")
 

--- a/README.md
+++ b/README.md
@@ -127,21 +127,21 @@ Returns the [Voronoi diagram](#voronoi) for the associated [points](#delaunay_po
 
 The Voronoi diagram’s associated [Delaunay triangulation](#delaunay).
 
+<a href="#voronoi_halfedgeIndex" name="voronoi_halfedgeIndex">#</a> <i>voronoi</i>.<b>halfedgeIndex</b>
+
+…
+
+<a href="#voronoi_hullIndex" name="voronoi_hullIndex">#</a> <i>voronoi</i>.<b>hullIndex</b>
+
+…
+
 <a href="#voronoi_circumcenters" name="voronoi_circumcenters">#</a> <i>voronoi</i>.<b>circumcenters</b>
 
 The [circumcenters](http://mathworld.wolfram.com/Circumcenter.html) of the Delaunay triangles as a Float64Array [*cx0*, *cy0*, *cx1*, *cy1*, …]. Each contiguous pair of coordinates *cx*, *cy* is the circumcenter for the corresponding triangle. These circumcenters form the coordinates of the Voronoi cell polygons.
 
-<a href="#voronoi_edges" name="voronoi_edges">#</a> <i>voronoi</i>.<b>edges</b>
-
-The edges of the Voronoi diagram, as an Uint32Array [*t0*, *t1*, *t2*, …] of Delaunay circumcenters, referenced by the <a href="#voronoi_index">index</a>.
-
-<a href="#voronoi_index" name="voronoi_index">#</a> <i>voronoi</i>.<b>index</b>
-
-The cells of the Voronoi diagram, described as an Uint32Array [*i0*, *j0*, *i1*, *j1*, …]. Each contiguous pair of indices *i*, *j* describes a polygon as a list of *j*-*i* circumcenter references in <a href="#voronoi_edges">edges</a>.
-
 <a href="#voronoi_vectors" name="voronoi_vectors">#</a> <i>voronoi</i>.<b>vectors</b>
 
-An Uint64Array [*vx0*, *vy0*, *wx0*, *wy0*, …] where each non-zero quadruple describes an open (infinite) cell on the outer hull, giving the directions of two open half-lines. 
+An Uint64Array [*vx0*, *vy0*, *wx0*, *wy0*, …] where each non-zero quadruple describes an open (infinite) cell on the outer hull, giving the directions of two open half-lines.
 
 <a href="#voronoi_xmin" name="voronoi_xmin">#</a> <i>voronoi</i>.<b>xmin</b><br>
 <a href="#voronoi_ymin" name="voronoi_ymin">#</a> <i>voronoi</i>.<b>ymin</b><br>

--- a/src/delaunay.js
+++ b/src/delaunay.js
@@ -60,7 +60,7 @@ export default class Delaunay {
       if (triangles[e] !== i) break; // bad triangulation
       e = halfedges[e];
       if (e === -1) {
-        const t = outedges[triangles[i]];
+        const t = triangles[outedges[i]];
         const dt = (x - points[t * 2]) ** 2 + (y - points[t * 2 + 1]) ** 2;
         if (dt < dc) dc = dt, c = t;
         break;

--- a/src/delaunay.js
+++ b/src/delaunay.js
@@ -1,6 +1,6 @@
 import Delaunator from "delaunator";
-import Path from "./path";
-import Polygon from "./polygon";
+import Path from "./path.js";
+import Polygon from "./polygon.js";
 import Voronoi from "./voronoi.js";
 
 const tau = 2 * Math.PI;

--- a/src/delaunay.js
+++ b/src/delaunay.js
@@ -23,7 +23,7 @@ export default class Delaunay {
     const inedges = this.inedges = new Int32Array(points.length / 2).fill(-1);
     const outedges = this.outedges = new Int32Array(points.length / 2).fill(-1);
 
-    // Compute an index from point to halfedge.
+    // Compute an index from each point to an (arbitrary) incoming halfedge.
     for (let e = 0, n = halfedges.length; e < n; ++e) {
       inedges[triangles[e % 3 === 2 ? e - 2 : e + 1]] = e;
     }

--- a/src/voronoi.js
+++ b/src/voronoi.js
@@ -115,7 +115,7 @@ export default class Voronoi {
     return this.delaunay._step(i, x, y) === i;
   }
   _cell(i) {
-    const {circumcenters, delaunay: {inedges, outedges, halfedges, triangles}} = this;
+    const {circumcenters, delaunay: {inedges, halfedges, triangles}} = this;
     const e0 = inedges[i];
     if (e0 === -1) return null; // coincident point
     const points = [];
@@ -126,12 +126,7 @@ export default class Voronoi {
       e = e % 3 === 2 ? e - 2 : e + 1;
       if (triangles[e] !== i) break; // bad triangulation
       e = halfedges[e];
-      if (e === -1) {
-        const t = Math.floor(outedges[i] / 3);
-        if (t !== Math.floor(e0 / 3)) points.push(circumcenters[t * 2], circumcenters[t * 2 + 1]);
-        break;
-      }
-    } while (e !== e0);
+    } while (e !== e0 && e !== -1);
     return points;
   }
   _clip(i) {

--- a/src/voronoi.js
+++ b/src/voronoi.js
@@ -34,11 +34,15 @@ export default class Voronoi {
     }
 
     // Compute exterior cell rays.
-    for (let n = hull.length, p0, x0, y0, p1 = triangles[hull[n - 1]] * 2, x1 = points[p1], y1 = points[p1 + 1], i = 0; i < n; ++i) {
-      p0 = p1, x0 = x1, y0 = y1, p1 = triangles[hull[i]] * 2, x1 = points[p1], y1 = points[p1 + 1];
-      vectors[p0 * 2 + 2] = vectors[p1 * 2] = y0 - y1;
-      vectors[p0 * 2 + 3] = vectors[p1 * 2 + 1] = x1 - x0;
-    }
+    let node = hull;
+    let p0, p1 = node.i * 2;
+    let x0, x1 = node.x;
+    let y0, y1 = node.y;
+    do {
+      node = node.next, p0 = p1, x0 = x1, y0 = y1, p1 = node.i * 4, x1 = node.x, y1 = node.y;
+      vectors[p0 + 2] = vectors[p1] = y0 - y1;
+      vectors[p0 + 3] = vectors[p1 + 1] = x1 - x0;
+    } while (node !== hull);
   }
   render(context) {
     const buffer = context == null ? context = new Path : undefined;
@@ -54,14 +58,16 @@ export default class Voronoi {
       const yj = circumcenters[tj + 1];
       this._renderSegment(xi, yi, xj, yj, context);
     }
-    for (let i = 0, n = hull.length; i < n; ++i) {
-      const t = Math.floor(hull[i] / 3) * 2;
+    let node = hull;
+    do {
+      node = node.next;
+      const t = Math.floor(node.t / 3) * 2;
       const x = circumcenters[t];
       const y = circumcenters[t + 1];
-      const v = triangles[hull[i]] * 4;
+      const v = node.i * 4;
       const p = this._project(x, y, vectors[v + 2], vectors[v + 3]);
       if (p) this._renderSegment(x, y, p[0], p[1], context);
-    }
+    } while (node !== hull);
     return buffer && buffer.value();
   }
   renderBounds(context) {

--- a/src/voronoi.js
+++ b/src/voronoi.js
@@ -165,10 +165,10 @@ export default class Voronoi {
       const t = triangles[e] * 2;
       points.push(circumcenters[t], circumcenters[t + 1]);
       e = e % 3 === 2 ? e - 2 : e + 1;
-      if (triangles[e] !== point) break; // bad triangulation
+      if (triangles[e] !== i) break; // bad triangulation
       e = halfedges[e];
       if (e === -1) {
-        const t = hullIndex[point];
+        const t = hullIndex[i];
         points.push(circumcenters[t], circumcenters[t + 1]);
         break;
       }

--- a/src/voronoi.js
+++ b/src/voronoi.js
@@ -17,8 +17,7 @@ export default class Voronoi {
       halfedgeIndex[triangles[e % 3 === 2 ? e - 2 : e + 1]] = e;
     }
 
-    // For points on the hull, index the incoming halfedge,
-    // and compute an index from hull point to the next hull point.
+    // For points on the hull, index both the incoming and outgoing halfedges.
     for (let i = 0, n = hull.length, i0, i1 = hull[n - 1]; i < n; ++i) {
       i0 = i1, i1 = hull[i];
       halfedgeIndex[triangles[i1]] = i0;

--- a/src/voronoi.js
+++ b/src/voronoi.js
@@ -35,7 +35,7 @@ export default class Voronoi {
 
     // Compute exterior cell rays.
     let node = hull;
-    let p0, p1 = node.i * 2;
+    let p0, p1 = node.i * 4;
     let x0, x1 = node.x;
     let y0, y1 = node.y;
     do {

--- a/src/voronoi.js
+++ b/src/voronoi.js
@@ -1,5 +1,5 @@
-import Path from "./path";
-import Polygon from "./polygon";
+import Path from "./path.js";
+import Polygon from "./polygon.js";
 
 export default class Voronoi {
   constructor(delaunay, [xmin, ymin, xmax, ymax] = [0, 0, 960, 500]) {

--- a/test/delaunay-test.js
+++ b/test/delaunay-test.js
@@ -58,15 +58,15 @@ tape("delaunay.voronoi([xmin, ymin, xmax, ymax]) uses the specified bounds", tes
 tape("delaunay.voronoi() returns the expected diagram", test => {
   let voronoi = Delaunay.from([[0, 0], [1, 0], [0, 1], [1, 1]]).voronoi();
   test.deepEqual(voronoi.circumcenters, Float64Array.of(0.5, 0.5, 0.5, 0.5));
-  // test.deepEqual(voronoi.edges, Uint32Array.of(0, 0, 1, 1, 0, 1));
-  // test.deepEqual(voronoi.index, Uint32Array.of(0, 1, 3, 5, 1, 3, 5, 6));
+  test.deepEqual(voronoi.halfedgeIndex, Int32Array.of(2, 4, 0, 3));
+  test.deepEqual(voronoi.hullIndex, Int32Array.of(3, 0, 4, 2));
   test.deepEqual(voronoi.vectors, Float64Array.of(0, -1, -1, 0, 1, 0, 0, -1, -1, 0, 0, 1, 0, 1, 1, 0));
 });
 
 tape("delaunay.voronoi() skips cells for coincident points", test => {
   let voronoi = Delaunay.from([[0, 0], [1, 0], [0, 1], [1, 0]]).voronoi([-1, -1, 2, 2]);
   test.deepEqual(voronoi.circumcenters, Float64Array.of(0.5, 0.5));
-  // test.deepEqual(voronoi.edges, Uint32Array.of(0, 0, 0));
-  // test.deepEqual(voronoi.index, Uint32Array.of(0, 1, 2, 3, 1, 2, 0, 0));
+  test.deepEqual(voronoi.halfedgeIndex, Int32Array.of(2, 1, 0, -1));
+  test.deepEqual(voronoi.hullIndex, Int32Array.of(1, 0, 2, -1));
   test.deepEqual(voronoi.vectors, Float64Array.of(0, -1, -1, 0, 1, 1, 0, -1, -1, 0, 1, 1, 0, 0, 0, 0));
 });

--- a/test/delaunay-test.js
+++ b/test/delaunay-test.js
@@ -6,6 +6,14 @@ tape("Delaunay.from(array)", test => {
   test.deepEqual(delaunay.points, Float64Array.of(0, 0, 1, 0, 0, 1, 1, 1));
   test.deepEqual(delaunay.triangles, Uint32Array.of(0, 2, 1, 2, 3, 1));
   test.deepEqual(delaunay.halfedges, Int32Array.of(-1, 5, -1, -1, -1, 1));
+  test.deepEqual(delaunay.inedges, Int32Array.of(2, 4, 0, 3));
+  test.deepEqual(delaunay.outedges, Int32Array.of(3, 0, 4, 2));
+});
+
+tape("Delaunay.from(array) handles coincident points", test => {
+  let delaunay = Delaunay.from([[0, 0], [1, 0], [0, 1], [1, 0]]);
+  test.deepEqual(delaunay.inedges, Int32Array.of(2, 1, 0, -1));
+  test.deepEqual(delaunay.outedges, Int32Array.of(1, 0, 2, -1));
 });
 
 tape("Delaunay.from(iterable)", test => {
@@ -58,15 +66,23 @@ tape("delaunay.voronoi([xmin, ymin, xmax, ymax]) uses the specified bounds", tes
 tape("delaunay.voronoi() returns the expected diagram", test => {
   let voronoi = Delaunay.from([[0, 0], [1, 0], [0, 1], [1, 1]]).voronoi();
   test.deepEqual(voronoi.circumcenters, Float64Array.of(0.5, 0.5, 0.5, 0.5));
-  test.deepEqual(voronoi.halfedgeIndex, Int32Array.of(2, 4, 0, 3));
-  test.deepEqual(voronoi.hullIndex, Int32Array.of(3, 0, 4, 2));
   test.deepEqual(voronoi.vectors, Float64Array.of(0, -1, -1, 0, 1, 0, 0, -1, -1, 0, 0, 1, 0, 1, 1, 0));
 });
 
 tape("delaunay.voronoi() skips cells for coincident points", test => {
   let voronoi = Delaunay.from([[0, 0], [1, 0], [0, 1], [1, 0]]).voronoi([-1, -1, 2, 2]);
   test.deepEqual(voronoi.circumcenters, Float64Array.of(0.5, 0.5));
-  test.deepEqual(voronoi.halfedgeIndex, Int32Array.of(2, 1, 0, -1));
-  test.deepEqual(voronoi.hullIndex, Int32Array.of(1, 0, 2, -1));
   test.deepEqual(voronoi.vectors, Float64Array.of(0, -1, -1, 0, 1, 1, 0, -1, -1, 0, 1, 1, 0, 0, 0, 0));
+});
+
+tape("delaunay.find(x, y) returns the index of the cell that contains the specified point", test => {
+  let delaunay = Delaunay.from([[0, 0], [300, 0], [0, 300], [300, 300], [100, 100]]);
+  test.deepEqual(delaunay.find(49, 49), 0);
+  test.deepEqual(delaunay.find(51, 51), 4);
+});
+
+tape("delaunay.find(x, y, i) traverses the convex hull", test => {
+  let delaunay = new Delaunay(Float64Array.of(509,253,426,240,426,292,567,272,355,356,413,392,319,408,374,285,327,303,381,215,475,319,301,352,247,426,532,334,234,366,479,375,251,302,340,170,160,377,626,317,177,296,322,243,195,422,241,232,585,358,666,406,689,343,172,198,527,401,766,350,444,432,117,316,267,170,580,412,754,425,117,231,725,300,700,222,438,165,703,168,558,221,475,211,491,125,216,166,240,108,783,266,640,258,184,77,387,90,162,125,621,162,296,78,532,154,763,199,132,165,422,343,312,128,125,77,450,95,635,106,803,415,714,63,529,87,388,152,575,126,573,64,726,381,773,143,787,67,690,117,813,203,811,319));
+  test.equal(delaunay.find(49, 311), 31);
+  test.equal(delaunay.find(49, 311, 22), 31);
 });

--- a/test/delaunay-test.js
+++ b/test/delaunay-test.js
@@ -58,15 +58,15 @@ tape("delaunay.voronoi([xmin, ymin, xmax, ymax]) uses the specified bounds", tes
 tape("delaunay.voronoi() returns the expected diagram", test => {
   let voronoi = Delaunay.from([[0, 0], [1, 0], [0, 1], [1, 1]]).voronoi();
   test.deepEqual(voronoi.circumcenters, Float64Array.of(0.5, 0.5, 0.5, 0.5));
-  test.deepEqual(voronoi.edges, Uint32Array.of(0, 0, 1, 1, 0, 1));
-  test.deepEqual(voronoi.index, Uint32Array.of(0, 1, 3, 5, 1, 3, 5, 6));
+  // test.deepEqual(voronoi.edges, Uint32Array.of(0, 0, 1, 1, 0, 1));
+  // test.deepEqual(voronoi.index, Uint32Array.of(0, 1, 3, 5, 1, 3, 5, 6));
   test.deepEqual(voronoi.vectors, Float64Array.of(0, -1, -1, 0, 1, 0, 0, -1, -1, 0, 0, 1, 0, 1, 1, 0));
 });
 
 tape("delaunay.voronoi() skips cells for coincident points", test => {
   let voronoi = Delaunay.from([[0, 0], [1, 0], [0, 1], [1, 0]]).voronoi([-1, -1, 2, 2]);
   test.deepEqual(voronoi.circumcenters, Float64Array.of(0.5, 0.5));
-  test.deepEqual(voronoi.edges, Uint32Array.of(0, 0, 0));
-  test.deepEqual(voronoi.index, Uint32Array.of(0, 1, 2, 3, 1, 2, 0, 0));
+  // test.deepEqual(voronoi.edges, Uint32Array.of(0, 0, 0));
+  // test.deepEqual(voronoi.index, Uint32Array.of(0, 1, 2, 3, 1, 2, 0, 0));
   test.deepEqual(voronoi.vectors, Float64Array.of(0, -1, -1, 0, 1, 1, 0, -1, -1, 0, 1, 1, 0, 0, 0, 0));
 });

--- a/test/voronoi-test.js
+++ b/test/voronoi-test.js
@@ -2,18 +2,6 @@ import tape from "@observablehq/tape";
 import Delaunay from "../src/delaunay.js";
 import Context from "./context";
 
-tape("voronoi.find(x, y) returns the index of the cell that contains the specified point", test => {
-  let voronoi = Delaunay.from([[0, 0], [300, 0], [0, 300], [300, 300], [100, 100]]).voronoi();
-  test.deepEqual(voronoi.find(49, 49), 0);
-  test.deepEqual(voronoi.find(51, 51), 4);
-});
-
-tape("voronoi.find(x, y, i) traverses the convex hull", test => {
-  let voronoi = new Delaunay(Float64Array.of(509,253,426,240,426,292,567,272,355,356,413,392,319,408,374,285,327,303,381,215,475,319,301,352,247,426,532,334,234,366,479,375,251,302,340,170,160,377,626,317,177,296,322,243,195,422,241,232,585,358,666,406,689,343,172,198,527,401,766,350,444,432,117,316,267,170,580,412,754,425,117,231,725,300,700,222,438,165,703,168,558,221,475,211,491,125,216,166,240,108,783,266,640,258,184,77,387,90,162,125,621,162,296,78,532,154,763,199,132,165,422,343,312,128,125,77,450,95,635,106,803,415,714,63,529,87,388,152,575,126,573,64,726,381,773,143,787,67,690,117,813,203,811,319)).voronoi();
-  test.equal(voronoi.find(49, 311), 31);
-  test.equal(voronoi.find(49, 311, 22), 31);
-});
-
 tape("voronoi.renderCell(i, context) is a noop for coincident points", test => {
   let voronoi = Delaunay.from([[0, 0], [1, 0], [0, 1], [1, 0]]).voronoi([-1, -1, 2, 2]);
   test.equal(voronoi.renderCell(3, {}), undefined);


### PR DESCRIPTION
Instead of precomputing the sequence of halfedges for each input site, the Voronoi constructor now computes an index from point id to starting halfedge id, such that the neighboring points can be computed lazily. For points on the hull, the starting halfedge is the incoming edge on the hull; a separate hull index is also needed to store the outgoing hull edge.

To handle coincident input points, these indexes are initialized with -1.

Open questions: 

1. Should these indexes be computed in the Delaunay constructor rather than the Voronoi constructor? It’d be nice to have them for traversing the Delaunay triangulation, for example to construct the [nearest neighbor graph](https://beta.observablehq.com/@mbostock/nearest-neighbor-graph). Then the Voronoi constructor would only be responsible for computing the circumcenters and hull vectors. And then I could add neighbor iteration and nearest-neighbor computation to the Delaunay class, and move *voronoi*.find to *delaunay*.find, without needing to compute circumcenters.

2. Suggestions for better names than “halfedgeIndex” and “hullIndex”? I’m tempted to name them “incoming” and “outgoing” but that’s a little vague…

Fixes #34. /cc @redblobgames