### PR TITLE
Fix Delaunay and Voronoi for degenerate cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,14 +63,7 @@ See also [*delaunay*.render](#delaunay_render).
 
 <a href="#delaunay_hull" name="delaunay_hull">#</a> <i>delaunay</i>.<b>hull</b>
 
-An arbitrary *node* on the convex hull. The convex hull is represented as a linked list of nodes, which each *node* being an object with the following properties:
-
-* *node*.i - the index of the associated point
-* *node*.x - the *x*-coordinate of the associated point
-* *node*.y - the *y*-coordinate of the associated point
-* *node*.t - the index of the (incoming or outgoing?) associated halfedge
-* *node*.next - the next *node* on the hull
-* *node*.prev - the previous *node* on the hull
+An Int32Array of point indexes that form the convex hull in counterclockwise order.
 
 See also [*delaunay*.renderHull](#delaunay_renderHull).
 
@@ -94,10 +87,6 @@ See also [*delaunay*.renderTriangle](#delaunay_renderTriangle).
 <a href="#delaunay_inedges" name="delaunay_inedges">#</a> <i>delaunay</i>.<b>inedges</b>
 
 The incoming halfedge indexes as a Int32Array [*e0*, *e1*, *e2*, …]. For each point *i*, *inedges*[*i*] is the halfedge index *e* of an incoming halfedge. For coincident points, the halfedge index is -1; for points on the convex hull, the incoming halfedge is on the convex hull; for other points, the choice of incoming halfedge is arbitrary. The *inedges* table can be used to traverse the Delaunay triangulation; see also [*delaunay*.neighbors](#delaunay_neighbors).
-
-<a href="#delaunay_outedges" name="delaunay_outedges">#</a> <i>delaunay</i>.<b>outedges</b>
-
-The outgoing halfedge indexes as a Int32Array [*e0*, *e1*, *e2*, …]. For each point *i* on the convex hull, *outedges*[*i*] is the halfedge index *e* of the corresponding outgoing halfedge; for other points, the halfedge index is -1. The *outedges* table can be used to traverse the Delaunay triangulation; see also [*delaunay*.neighbors](#delaunay_neighbors).
 
 <a href="#delaunay_find" name="delaunay_find">#</a> <i>delaunay</i>.<b>find</b>(<i>x</i>, <i>y</i>[, <i>i</i>]) [<>](https://github.com/d3/d3-delaunay/blob/master/src/delaunay.js "Source")
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ See also [*delaunay*.render](#delaunay_render).
 
 <a href="#delaunay_hull" name="delaunay_hull">#</a> <i>delaunay</i>.<b>hull</b>
 
-An Int32Array of point indexes that form the convex hull in counterclockwise order.
+An Int32Array of point indexes that form the convex hull in counterclockwise order. If the points are collinear, returns them ordered.
 
 See also [*delaunay*.renderHull](#delaunay_renderHull).
 
@@ -133,6 +133,8 @@ Returns the closed polygon [[*x0*, *y0*], [*x1*, *y1*], [*x2*, *y2*], [*x0*, *y0
 <a href="#delaunay_voronoi" name="delaunay_voronoi">#</a> <i>delaunay</i>.<b>voronoi</b>([<i>bounds</i>]) [<>](https://github.com/d3/d3-delaunay/blob/master/src/delaunay.js "Source")
 
 Returns the [Voronoi diagram](#voronoi) for the associated [points](#delaunay_points). When rendering, the diagram will be clipped to the specified *bounds* = [*xmin*, *ymin*, *xmax*, *ymax*]. If *bounds* is not specified, it defaults to [0, 0, 960, 500]. See [To Infinity and Back Again](https://observablehq.com/@mbostock/to-infinity-and-back-again) for an interactive explanation of Voronoi cell clipping.
+
+The Voronoi diagram is returned even in degenerate cases where no triangulation exists — namely 0, 1 or 2 points, and collinear points.
 
 ### Voronoi
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "unpkg": "dist/d3-delaunay.min.js",
   "module": "src/index.js",
   "dependencies": {
-    "delaunator": "^3.0.2"
+    "delaunator": "4"
   },
   "devDependencies": {
     "@observablehq/tape": "~0.0.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "unpkg": "dist/d3-delaunay.min.js",
   "module": "src/index.js",
   "dependencies": {
-    "delaunator": "^2.0.0"
+    "delaunator": "^3.0.2"
   },
   "devDependencies": {
     "@observablehq/tape": "~0.0.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,7 +12,7 @@ const config = {
     indent: false,
     extend: true,
     banner: `// ${meta.homepage} v${meta.version} Copyright ${(new Date).getFullYear()} ${meta.author.name}
-// https://github.com/mapbox/delaunator v${require("delaunator/package.json").version}. Copyright 2017 Mapbox, Inc.`,
+// https://github.com/mapbox/delaunator v${require("delaunator/package.json").version}. Copyright 2019 Mapbox, Inc.`,
     globals: Object.assign({}, ...Object.keys(meta.dependencies || {}).filter(key => /^d3-/.test(key)).map(key => ({[key]: "d3"})))
   },
   plugins: [

--- a/src/delaunay.js
+++ b/src/delaunay.js
@@ -21,26 +21,24 @@ export default class Delaunay {
     this.hull = hull;
     this.triangles = triangles;
     const inedges = this.inedges = new Int32Array(points.length / 2).fill(-1);
-    const outedges = this.outedges = new Int32Array(points.length / 2).fill(-1);
+    const hullIndex = this.hullIndex = new Int32Array(points.length / 2).fill(-1);
 
-    // Compute an index from each point to an (arbitrary) incoming halfedge.
+    // Compute an index from each point to an (arbitrary) incoming halfedge
+    // Used to give the first neighbor of each point; for this reason,
+    // on the hull we give priority to exterior halfedges
     for (let e = 0, n = halfedges.length; e < n; ++e) {
-      inedges[triangles[e % 3 === 2 ? e - 2 : e + 1]] = e;
+      const p = triangles[e % 3 === 2 ? e - 2 : e + 1];
+      if (halfedges[e] === -1 || inedges[p] === -1) inedges[p] = e;
     }
-
-    // For points on the hull, index both the incoming and outgoing halfedges.
-    let node0, node1 = hull;
-    do {
-      node0 = node1, node1 = node1.next;
-      inedges[node1.i] = node0.t;
-      outedges[node0.i] = node1.t;
-    } while (node1 !== hull);
+    for (let i = 0; i < hull.length; ++i) {
+      hullIndex[hull[i]] = i;
+    }
   }
   voronoi(bounds) {
     return new Voronoi(this, bounds);
   }
   *neighbors(i) {
-    const {inedges, outedges, halfedges, triangles} = this;
+    const {inedges, hull, hullIndex, halfedges, triangles} = this;
     const e0 = inedges[i];
     if (e0 === -1) return; // coincident point
     let e = e0;
@@ -49,7 +47,7 @@ export default class Delaunay {
       e = e % 3 === 2 ? e - 2 : e + 1;
       if (triangles[e] !== i) return; // bad triangulation
       e = halfedges[e];
-      if (e === -1) return yield triangles[outedges[i]];
+      if (e === -1) return yield hull[(hullIndex[i] + 1) % hull.length];
     } while (e !== e0);
   }
   find(x, y, i = 0) {
@@ -96,10 +94,11 @@ export default class Delaunay {
   }
   renderHull(context) {
     const buffer = context == null ? context = new Path : undefined;
-    const {hull} = this;
-    let node = hull;
-    context.moveTo(node.x, node.y);
-    while (node = node.next, node !== hull) context.lineTo(node.x, node.y);
+    const {hull, points} = this;
+    for (let i = 0, h; i < hull.length; ++i) {
+      h = hull[i];
+      context[i ? "lineTo" : "moveTo"](points[2 * h], points[2 * h + 1]);
+    }
     context.closePath();
     return buffer && buffer.value();
   }

--- a/src/voronoi.js
+++ b/src/voronoi.js
@@ -34,19 +34,21 @@ export default class Voronoi {
     }
 
     // Compute exterior cell rays.
-    let node = hull;
-    let p0, p1 = node.i * 4;
-    let x0, x1 = node.x;
-    let y0, y1 = node.y;
-    do {
-      node = node.next, p0 = p1, x0 = x1, y0 = y1, p1 = node.i * 4, x1 = node.x, y1 = node.y;
+    let h = hull[hull.length - 1];
+    let p0, p1 = h * 4;
+    let x0, x1 = points[2 * h];
+    let y0, y1 = points[2 * h + 1];
+    for (let i = 0; i < hull.length; ++i) {
+      h = hull[i];
+      p0 = p1, x0 = x1, y0 = y1;
+      p1 = h * 4, x1 = points[2 * h], y1 = points[2 * h + 1];
       vectors[p0 + 2] = vectors[p1] = y0 - y1;
       vectors[p0 + 3] = vectors[p1 + 1] = x1 - x0;
-    } while (node !== hull);
+    }
   }
   render(context) {
     const buffer = context == null ? context = new Path : undefined;
-    const {delaunay: {halfedges, hull}, circumcenters, vectors} = this;
+    const {delaunay: {halfedges, inedges, hull}, circumcenters, vectors} = this;
     for (let i = 0, n = halfedges.length; i < n; ++i) {
       const j = halfedges[i];
       if (j < i) continue;
@@ -58,16 +60,15 @@ export default class Voronoi {
       const yj = circumcenters[tj + 1];
       this._renderSegment(xi, yi, xj, yj, context);
     }
-    let node = hull;
-    do {
-      node = node.next;
-      const t = Math.floor(node.t / 3) * 2;
+    let h0, h1 = hull[hull.length - 1];
+    for (let i = 0; i < hull.length; ++i) {
+      const t = Math.floor(inedges[h] / 3) * 2;
       const x = circumcenters[t];
       const y = circumcenters[t + 1];
-      const v = node.i * 4;
+      const v = h0 * 4;
       const p = this._project(x, y, vectors[v + 2], vectors[v + 3]);
       if (p) this._renderSegment(x, y, p[0], p[1], context);
-    } while (node !== hull);
+    }
     return buffer && buffer.value();
   }
   renderBounds(context) {

--- a/test/delaunay-test.js
+++ b/test/delaunay-test.js
@@ -1,5 +1,6 @@
 import tape from "@observablehq/tape";
 import Delaunay from "../src/delaunay.js";
+import Context from "./context";
 
 tape("Delaunay.from(array)", test => {
   let delaunay = Delaunay.from([[0, 0], [1, 0], [0, 1], [1, 1]]);
@@ -7,13 +8,19 @@ tape("Delaunay.from(array)", test => {
   test.deepEqual(delaunay.triangles, Uint32Array.of(0, 2, 1, 2, 3, 1));
   test.deepEqual(delaunay.halfedges, Int32Array.of(-1, 5, -1, -1, -1, 1));
   test.deepEqual(delaunay.inedges, Int32Array.of(2, 4, 0, 3));
-  test.deepEqual(delaunay.outedges, Int32Array.of(3, 0, 4, 2));
+  test.deepEqual(Array.from(delaunay.neighbors(0)), [1, 2]);
+  test.deepEqual(Array.from(delaunay.neighbors(1)), [3, 2, 0]);
+  test.deepEqual(Array.from(delaunay.neighbors(2)), [0, 1, 3]);
+  test.deepEqual(Array.from(delaunay.neighbors(3)), [2, 1]);
 });
 
 tape("Delaunay.from(array) handles coincident points", test => {
   let delaunay = Delaunay.from([[0, 0], [1, 0], [0, 1], [1, 0]]);
   test.deepEqual(delaunay.inedges, Int32Array.of(2, 1, 0, -1));
-  test.deepEqual(delaunay.outedges, Int32Array.of(1, 0, 2, -1));
+  test.deepEqual(Array.from(delaunay.neighbors(0)), [1, 2]);
+  test.deepEqual(Array.from(delaunay.neighbors(1)), [2, 0]);
+  test.deepEqual(Array.from(delaunay.neighbors(2)), [0, 1]);
+  test.deepEqual(Array.from(delaunay.neighbors(3)), []);
 });
 
 tape("Delaunay.from(iterable)", test => {
@@ -93,4 +100,10 @@ tape("delaunay.find(x, y, i) traverses the convex hull", test => {
   let delaunay = new Delaunay(Float64Array.of(509,253,426,240,426,292,567,272,355,356,413,392,319,408,374,285,327,303,381,215,475,319,301,352,247,426,532,334,234,366,479,375,251,302,340,170,160,377,626,317,177,296,322,243,195,422,241,232,585,358,666,406,689,343,172,198,527,401,766,350,444,432,117,316,267,170,580,412,754,425,117,231,725,300,700,222,438,165,703,168,558,221,475,211,491,125,216,166,240,108,783,266,640,258,184,77,387,90,162,125,621,162,296,78,532,154,763,199,132,165,422,343,312,128,125,77,450,95,635,106,803,415,714,63,529,87,388,152,575,126,573,64,726,381,773,143,787,67,690,117,813,203,811,319));
   test.equal(delaunay.find(49, 311), 31);
   test.equal(delaunay.find(49, 311, 22), 31);
+});
+
+tape("delaunay.renderHull(context) is closed", test => {
+  let delaunay = Delaunay.from([[0, 0], [1, 0], [0, 1], [1, 1]]);
+  let context = new Context;
+  test.equal((delaunay.renderHull(context), context.toString()), `M0,1L1,1L1,0L0,0Z`);
 });

--- a/test/delaunay-test.js
+++ b/test/delaunay-test.js
@@ -82,6 +82,31 @@ tape("delaunay.voronoi() skips cells for coincident points", test => {
   test.deepEqual(voronoi.vectors, Float64Array.of(0, -1, -1, 0, 1, 1, 0, -1, -1, 0, 1, 1, 0, 0, 0, 0));
 });
 
+tape("delaunay.voronoi() for zero point returns expected values", test => {
+  let voronoi = Delaunay.from([]).voronoi([-1, -1, 2, 2]);
+  test.equal(voronoi.render(), null);
+});
+
+tape("delaunay.voronoi() for one point returns the bounding rectangle", test => {
+  let voronoi = Delaunay.from([[0, 0]]).voronoi([-1, -1, 2, 2]);
+  test.equal(voronoi.renderCell(0), "M2,-1L2,2L-1,2L-1,-1Z");
+  test.equal(voronoi.render(), null);
+});
+
+tape("delaunay.voronoi() for two points", test => {
+  let voronoi = Delaunay.from([[0, 0], [1, 0], [1, 0], [1, 0]]).voronoi([-1, -1, 2, 2]);
+  test.equal(voronoi.renderCell(0), "M0.5,2L-1,2L-1,-1L0.5,-1L0.5,2Z");
+  test.equal(voronoi.delaunay.find(-1,0), 0);
+  test.equal(voronoi.delaunay.find(2,0), 1);
+});
+
+tape("delaunay.voronoi() for collinear points", test => {
+  let voronoi = Delaunay.from([[0, 0], [1, 0], [-1, 0]]).voronoi([-1, -1, 2, 2]);
+  test.deepEqual(Array.from(voronoi.delaunay.neighbors(0)).sort(), [1, 2]);
+  test.deepEqual(Array.from(voronoi.delaunay.neighbors(1)), [0]);
+  test.deepEqual(Array.from(voronoi.delaunay.neighbors(2)), [0]);
+});
+
 tape("delaunay.find(x, y) returns the index of the cell that contains the specified point", test => {
   let delaunay = Delaunay.from([[0, 0], [300, 0], [0, 300], [300, 300], [100, 100]]);
   test.equal(delaunay.find(49, 49), 0);

--- a/yarn.lock
+++ b/yarn.lock
@@ -218,9 +218,10 @@ del@^2.0.2:
     pinkie-promise "^2.0.0"
     rimraf "^2.2.8"
 
-delaunator@^2.0.0:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/delaunator/-/delaunator-2.0.5.tgz#c2a9ba2cf3d5aaab8fa0aa3ae82426d3fc0aeaf5"
+delaunator@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/delaunator/-/delaunator-3.0.2.tgz#62d5d9699cd64a736a2bb9c4d957d662452808d0"
+  integrity sha512-GNSex8jhF1mcqtNAMYvdZ6Ng7YieYNlbOq2xshyZhLc98P8y5O7Vm6buw4A60wGOd9qvK9RcIMm5qoe4PncAPw==
 
 doctrine@^2.1.0:
   version "2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -218,10 +218,10 @@ del@^2.0.2:
     pinkie-promise "^2.0.0"
     rimraf "^2.2.8"
 
-delaunator@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/delaunator/-/delaunator-3.0.2.tgz#62d5d9699cd64a736a2bb9c4d957d662452808d0"
-  integrity sha512-GNSex8jhF1mcqtNAMYvdZ6Ng7YieYNlbOq2xshyZhLc98P8y5O7Vm6buw4A60wGOd9qvK9RcIMm5qoe4PncAPw==
+delaunator@4:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/delaunator/-/delaunator-4.0.0.tgz#3630f477b4923f472f534c62a028aeca6fe22d96"
+  integrity sha512-KzVgOHix5xaIVzZSfbv3Uzw9aI7mQNDet4Yd2p+tBNkfNHMFJbjbVa3q0nC7q7TjWZLX49QbzcT+pXazXX3Qmg==
 
 doctrine@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
For 0, 1, 2 points, and for collinear points:
- returns the correct topology (neighbors, find)
- returns the correct Voronoi cells (bounding box, half plane…)
- resorts to deterministic jittering only in the case of multiple collinear points

Needs this change to Delaunator@3: Fil/delaunator@b968020 ([Delaunator#47](https://github.com/mapbox/delaunator/pull/47))

based on branch delaunator3 (#63).