### PR TITLE
remove zero-length edges from clipped voronoi cells

### DIFF
--- a/src/voronoi.js
+++ b/src/voronoi.js
@@ -101,7 +101,8 @@ export default class Voronoi {
     if (points === null) return;
     context.moveTo(points[0], points[1]);
     for (let i = 2, n = points.length; i < n; i += 2) {
-      context.lineTo(points[i], points[i + 1]);
+      if (points[i] !== points[i-2] || points[i+1] !== points[i-1])
+        context.lineTo(points[i], points[i + 1]);
     }
     context.closePath();
     return buffer && buffer.value();

--- a/test/voronoi-test.js
+++ b/test/voronoi-test.js
@@ -43,3 +43,8 @@ tape("voronoi.update() updates a degenerate voronoi", test => {
   const p = voronoi.update().cellPolygon(1);
   test.deepEqual(p, [[-500, 500], [-500, -140], [-240, -140], [-140, 60], [-140, 500], [-500, 500]]);
 });
+
+tape("zero-length edges are removed", test => {
+   const voronoi = Delaunay.from([[50, 10], [10, 50], [10, 10], [200, 100]]).voronoi([40, 40, 440, 180]);
+   test.equal(voronoi.cellPolygon(0).length, 4);
+})


### PR DESCRIPTION
fixes #42 ; see https://observablehq.com/d/93c4555b681dcf86 for an example