### PR TITLE
voronoi.neighbors

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,10 @@ The bounds of the viewport [*xmin*, *ymin*, *xmax*, *ymax*] for rendering the Vo
 
 Returns true if the cell with the specified index *i* contains the specified point ⟨*x*, *y*⟩. (This method is not affected by the associated Voronoi diagram’s viewport [bounds](#voronoi_xmin).)
 
+<a href="#voronoi_neighbors" name="voronoi_neighbors">#</a> <i>voronoi</i>.<b>neighbors</b>(<i>i</i>) [<>](https://github.com/d3/d3-delaunay/blob/master/src/voronoi.js "Source")
+
+Returns an iterable over the indexes of the cells that share a common edge with the specified cell *i*. Voronoi neighbors are always neighbors on the Delaunay graph, but the converse is false when the common edge has been clipped out by the Voronoi diagram’s viewport.
+
 <a href="#voronoi_render" name="voronoi_render">#</a> <i>voronoi</i>.<b>render</b>([<i>context</i>]) [<>](https://github.com/d3/d3-delaunay/blob/master/src/voronoi.js "Source")
 
 <img alt="voronoi.render" src="https://raw.githubusercontent.com/d3/d3-delaunay/master/img/voronoi-mesh.png">

--- a/src/voronoi.js
+++ b/src/voronoi.js
@@ -146,6 +146,25 @@ export default class Voronoi {
     if ((x = +x, x !== x) || (y = +y, y !== y)) return false;
     return this.delaunay._step(i, x, y) === i;
   }
+  *neighbors(i) {
+    const ci = this._clip(i);
+    if (ci) for (const j of this.delaunay.neighbors(i)) {
+      const cj = this._clip(j);
+      // find the common edge
+      if (cj) loop: for (let ai = 0, li = ci.length; ai < li; ai += 2) {
+        for (let aj = 0, lj = cj.length; aj < lj; aj += 2) {
+          if (ci[ai] == cj[aj]
+          && ci[ai + 1] == cj[aj + 1]
+          && ci[(ai + 2) % li] == cj[(aj + lj - 2) % lj]
+          && ci[(ai + 3) % li] == cj[(aj + lj - 1) % lj]
+          ) {
+            yield j;
+            break loop;
+          }
+        }
+      }
+    }
+  }
   _cell(i) {
     const {circumcenters, delaunay: {inedges, halfedges, triangles}} = this;
     const e0 = inedges[i];

--- a/test/voronoi-test.js
+++ b/test/voronoi-test.js
@@ -51,6 +51,16 @@ tape("zero-length edges are removed", test => {
    test.deepEqual(voronoi2.cellPolygon(0), [[15, 20], [0, 20], [0, 0], [15, 0], [15, 20]]);
 });
 
+tape("voronoi neighbors are clipped", test => {
+   const voronoi = Delaunay.from([[300, 10], [200, 100], [300, 100], [10, 10], [350, 200], [350, 400]]).voronoi([0, 0, 500, 150]);
+   test.deepEqual([...voronoi.neighbors(0)].sort(), [1, 2]);
+   test.deepEqual([...voronoi.neighbors(1)].sort(), [0, 2]);
+   test.deepEqual([...voronoi.neighbors(2)].sort(), [0, 1, 4]);
+   test.deepEqual([...voronoi.neighbors(3)].sort(), []);
+   test.deepEqual([...voronoi.neighbors(4)].sort(), [2]);
+   test.deepEqual([...voronoi.neighbors(5)].sort(), []);
+});
+
 tape("unnecessary points on the corners are avoided (#88)", test => {
   for (const [points, lengths] of [
     [ [[289,25],[3,22],[93,165],[282,184],[65,89]], [ 6, 4, 6, 5, 6 ] ],


### PR DESCRIPTION
Returns an iterable over the indexes of the cells that share a common edge with the specified cell *i*. Voronoi neighbors are always neighbors on the Delaunay graph, but the converse is false when the common edge has been clipped out by the Voronoi diagram’s viewport.

fixes https://github.com/d3/d3-delaunay/issues/96