### PR TITLE
Subtle out of bounds checking need documenting

### DIFF
--- a/src/voronoi.js
+++ b/src/voronoi.js
@@ -273,6 +273,10 @@ export default class Voronoi {
         case 0b1001: e0 = 0b0001; continue; // bottom-left
         case 0b0001: e0 = 0b0101, x = this.xmin, y = this.ymin; break; // left
       }
+
+      // Implicit out of bounds checking.
+      // P[j] or P[j+1] may become undefined and the conditional statement will be
+      // executed.
       if ((P[j] !== x || P[j + 1] !== y) && this.contains(i, x, y)) {
         P.splice(j, 0, x, y), j += 2;
       }


### PR DESCRIPTION
I appreciate the sparse documentation in this code. The coding style is good enough that  the code mostly speak for itself.

I want to talk about the implicit out of bounds checking which I think needs documenting 
as it will go unnoticed by the casual reader.

This can be seen by running the second half of ""zero-length edges are removed"
in a debugger.

```
tape("zero-length edges are removed", test => {
  //  const voronoi1 = Delaunay.from([[50, 10], [10, 50], [10, 10], [200, 100]]).voronoi([40, 40, 440, 180]);
  //  test.equal(voronoi1.cellPolygon(0).length, 4);
   const voronoi2 = Delaunay.from([[10, 10], [20, 10]]).voronoi([0, 0, 30, 20]);
   test.deepEqual(voronoi2.cellPolygon(0), [[15, 20], [0, 20], [0, 0], [15, 0], [15, 20]]);
});
```

By out of bounds checking I mean :- 
P[j] frequently becomes undefined as the code runs off the end of the P array and the if statement functions in ways which are not obvious.

I just think anyone in future modifying this code would want this part of the design highlighted.
