### PR TITLE
Minor: _ClipFinite() Prevent the propagation of undefined.

### DIFF
--- a/src/voronoi.js
+++ b/src/voronoi.js
@@ -198,7 +198,7 @@ export default class Voronoi {
     let P = null;
     let x0, y0, x1 = points[n - 2], y1 = points[n - 1];
     let c0, c1 = this._regioncode(x1, y1);
-    let e0, e1;
+    let e0, e1 = 0b000;
     for (let j = 0; j < n; j += 2) {
       x0 = x1, y0 = y1, x1 = points[j], y1 = points[j + 1];
       c0 = c1, c1 = this._regioncode(x1, y1);


### PR DESCRIPTION
This is a minor cosmetic change. 

When the following code is ported into a language which  detects and the rejects  the propagation of undefined values form variable to variable..  I see this is happening in our java script code.

Looking at the code below as it flows into the for loop and into the complex branch of if statements 
I see e1 can be read  before it is set. ( I have edited the line with a comment ) 

and when I run one of the  standard tests -- using a debugger.
I see the subsequent  line 

if (e0 && e1 ) {}

being computed as 

if (undefined && 8 ) {}

this works  ok because the natural initial value for e1 is actually 0b0000

Anyway this "read before write error"  should be removed as it is a maintenance hazard.

```
    let e0, e1;
    for (let j = 0; j < n; j += 2) {
      x0 = x1, y0 = y1, x1 = points[j], y1 = points[j + 1];
      c0 = c1, c1 = this._regioncode(x1, y1);
      if (c0 === 0 && c1 === 0) {
        e0 = e1, e1 = 0;
        if (P) P.push(x1, y1);
        else P = [x1, y1];
      } else {
        let S, sx0, sy0, sx1, sy1;
        if (c0 === 0) {
          if ((S = this._clipSegment(x0, y0, x1, y1, c0, c1)) === null) continue;
          [sx0, sy0, sx1, sy1] = S;
        } else {
          if ((S = this._clipSegment(x1, y1, x0, y0, c1, c0)) === null) continue;
          [sx1, sy1, sx0, sy0] = S;
          e0 = e1, e1 = this._edgecode(sx0, sy0);  // e0 = e1 --- propagation of undefined happens here.
          if (e0 && e1) this._edge(i, e0, e1, P, P.length);
          if (P) P.push(sx0, sy0);
          else P = [sx0, sy0];
        }
        e0 = e1, e1 = this._edgecode(sx1, sy1);
        if (e0 && e1) this._edge(i, e0, e1, P, P.length);
        if (P) P.push(sx1, sy1);
        else P = [sx1, sy1];
      }
    }
```