### PR TITLE
Robust circumcenters when the hull is collinear

### DIFF
--- a/src/voronoi.js
+++ b/src/voronoi.js
@@ -18,7 +18,7 @@ export default class Voronoi {
   }
   _init() {
     const {delaunay: {points, hull, triangles}, vectors} = this;
-    let b; // lazily computed barycenter of the hull
+    let bx, by; // lazily computed barycenter of the hull
 
     // Compute circumcenters.
     const circumcenters = this.circumcenters = this._circumcenters.subarray(0, triangles.length / 3 * 2);
@@ -43,12 +43,12 @@ export default class Voronoi {
         // For a degenerate triangle, the circumcenter is at the infinity, in a
         // direction orthogonal to the halfedge and away from the “center” of
         // the diagram <bx, by>, defined as the hull’s barycenter.
-        if (!b) {
-          b = {x: 0, y: 0};
-          for (const i of hull) b.x += points[i * 2], b.y += points[i * 2 + 1];
-          b.x /= hull.length, b.y /= hull.length;
+        if (bx === undefined) {
+          bx = by = 0;
+          for (const i of hull) bx += points[i * 2], by += points[i * 2 + 1];
+          bx /= hull.length, by /= hull.length;
         }
-        const a = 1e9 * Math.sign((b.x - x1) * ey - (b.y - y1) * ex);
+        const a = 1e9 * Math.sign((bx - x1) * ey - (by - y1) * ex);
         x = (x1 + x3) / 2 - a * ey;
         y = (y1 + y3) / 2 + a * ex;
       } else {

--- a/test/voronoi-test.js
+++ b/test/voronoi-test.js
@@ -122,3 +122,9 @@ it("voronoi returns the expected result (#136)", () => {
   const voronoi = Delaunay.from(points).voronoi([0, 0, 1000, 1000]);
   assert.strictEqual(voronoi.cellPolygon(3).length, 6);
 });
+
+it("voronoi returns the expected result (#141)", () => {
+  const points = [[10, 190]].concat(Array.from({ length: 7 }, (d, i) => [i * 80, (i * 50) / 7]));
+  const voronoi = Delaunay.from(points).voronoi([1, 1, 499, 199]);
+  assert.deepEqual(Array.from(voronoi.cellPolygons(), (d) => d.length), [7, 5, 5, 5, 6, 5, 5, 5]);
+});


### PR DESCRIPTION
The failure reported in #141 came from the fact that the first point of the first triangle belonged to the collinear part of the hull, thus making the circumcenters of degenerate triangles (which need to be "projected to the infinite") go to either side arbitrarily. We want them to go "outwards".

The solution suggested here is to make sure we use a non-collinear reference (which I took to be the barycenter of the hull—could have been something else; but the first point of the first triangle was clearly a wrong bet). 

I've reduced the test case to:
`points = [[10, 190]].concat(Array.from({length: 7}, (d, i) => [i * 80, (i * 50) / 7]))`

*before*
![before](https://user-images.githubusercontent.com/7001/227723217-8068cebe-16fc-4488-88a3-debcb2521e6f.png)

*after*
![after](https://user-images.githubusercontent.com/7001/227723219-8ca7a8fd-8cf3-4c1c-a037-403dc6d8cad4.png)

fixes #141